### PR TITLE
switched avakas to use its own git native flavor in setup.py

### DIFF
--- a/avakas/flavors/base.py
+++ b/avakas/flavors/base.py
@@ -124,7 +124,6 @@ class AvakasLegacy(Avakas):
 
     def write_versionfile(self):
         """Write the version file"""
-
         path = os.path.join(self.directory, self.version_filename)
         version_file = open(path, 'w')
         version_file.write("%s\n" % self.version)

--- a/avakas/flavors/git.py
+++ b/avakas/flavors/git.py
@@ -41,9 +41,10 @@ class AvakasGitNative(Avakas):
         # pylint: disable=unused-argument
         return False
 
-    def __init__(self, filename, tag_prefix='v', **kwargs):
+    def __init__(self, filename, directory, tag_prefix='v', **kwargs):
         # not sure if setting tag_prefix to ! None is too prescriptive
-        super().__init__(**kwargs)
+
+        super().__init__(directory, **kwargs)
         self.tag_prefix = tag_prefix
         self.version_filename = filename
         self.repo = self.__load_git()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
-import os
 
+import avakas
 
 try:
     from setuptools import setup
@@ -11,14 +11,10 @@ except ImportError:
 
 
 def main():
-    vsn_path = "%s/version" % os.path.dirname(os.path.abspath(__file__))
-    if not os.path.exists(vsn_path):
-        print("%s is missing" % vsn_path)
-        sys.exit(1)
+    project = avakas.flavors.AvakasGitNative(
+        'version', ['.'], branch='mainline', tag_prefix='')
 
-    vsn_file = open(vsn_path, 'r')
-    version = vsn_file.read()
-    vsn_file.close()
+    version = project.read()
 
     setup(name='avakas',
           version=version,


### PR DESCRIPTION
This PR removes the requirement for poetry to be installed to create a version file when it's not checked in, as avakas setup.py currently requires a version file